### PR TITLE
added CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Footprint-App
+
+[![CircleCI Build Status](https://circleci.com/gh/ivanoblomov/Footprint-App/tree/master.png?circle-token=061f377bdfdf75f2bf14cdd0585da7822358afd9)](https://circleci.com/gh/ivanoblomov/Footprint-App/tree/master)


### PR DESCRIPTION
 ## Goal
Show CI status at a glance.

 ## Approach
1. [Create an API token in CircleCI](https://circleci.com/account/api) for GitHub.
2. Create `README.md` and add a link to CircleCI badge using token from 1.

 ## Deployment
Before merging, update both URLs with:
* correct GitHub path `https://app.circleci.com/jobs/github/sblackstealth/Footprint-App`
* a new, corresponding token (using step 1 above)

If done correctly, the `README` should look like [my fork's `README`](https://github.com/ivanoblomov/Footprint-App).