### PR TITLE
Demo: trigger eslint failure

### DIFF
--- a/bad_ternary.js
+++ b/bad_ternary.js
@@ -1,0 +1,1 @@
+var a = x ? true : false;


### PR DESCRIPTION
 ## Goal
Show what an `eslint` failure looks like.

 ## Approach
Trigger a [`no-unneeded-ternary` warning](https://eslint.org/docs/rules/no-unneeded-ternary) to show `eslint` is installed correctly.

 ## Deployment
*This branch is for demo purposes only:* When rebased with a master branch with a correctly configured linter, this branch should fail with a `no-unneeded-ternary` warning.