### PR TITLE
added badge rewards page theory to be plugged into homepage

### DIFF
--- a/src/components/badges/badges.js
+++ b/src/components/badges/badges.js
@@ -1,19 +1,15 @@
 import React,{ Component } from 'react';
-// import Slider from '../components/Slider'
-// import Neutralizor from '.../Neutralizor.png';
-// import Sustainilizer from '.../Sustainilizor.png';
 
-// chooseBadge=(<Slider/>)=>{
-//     let slider= <Slider/>
-//     if{ slider.value >=124 return Neutralizor}else{ return Sustainilizer}
-// }
+chooseBadge=(badge)=>{
+    return badge
+}
 class RewardsBadge extends Component {
     render(){
         return(
             <div className="badgePage">
              <p>
                 Congratulations  
-                Thanks for being a Sustainilizor
+                Thanks for being a {chooseBadge()}
              </p>
                 
              <img src={chooseBadge()}></img>

--- a/src/components/badges/badges.js
+++ b/src/components/badges/badges.js
@@ -1,6 +1,6 @@
 import React,{ Component } from 'react';
 
-chooseBadge=(badge)=>{
+const chooseBadge=(badge)=>{
     return badge
 }
 class RewardsBadge extends Component {
@@ -18,4 +18,5 @@ class RewardsBadge extends Component {
         )
     }
 }
-export default RewardsBadge;
+export {RewardsBadge,
+chooseBadge};


### PR DESCRIPTION
Closes:

 ## Goal
What problem does this pull request solve? Created the rewards page for badge display after Cloverly purchase completed.

 ## Approach
Describe the approach you chose to solve the above problem. Created a function that takes the badge information from the slider state to display proper rewards badge.

 ## Deployment
This is OPTIONAL. Let us know if this pull request needs anything special before, during, or after deployment. gonna need to update the main page and pass badges and {choosebadge}. display RewardsBadge component after purchase completed
